### PR TITLE
Patch for media download

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ weixin-java-tools
 <dependency>
   <groupId>me.chanjar</groupId>
   <artifactId>weixin-java-mp</artifactId>
-  <version>1.1.6</version>
+  <version>1.1.7</version>
 </dependency>
 ```
 

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/MediaDownloadRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/MediaDownloadRequestExecutor.java
@@ -63,16 +63,24 @@ public class MediaDownloadRequestExecutor implements RequestExecutor<File, Strin
         throw new WxErrorException(WxError.fromJson(responseContent));
       }
     }
-    InputStream inputStream = InputStreamResponseHandler.INSTANCE.handleResponse(response);
     
-    // 视频文件不支持下载
-    String fileName = getFileName(response);
-    if (StringUtils.isBlank(fileName)) {
-      return null;
+    InputStream inputStream = null;
+    try{
+	    inputStream = InputStreamResponseHandler.INSTANCE.handleResponse(response);
+	    
+	    // 视频文件不支持下载
+	    String fileName = getFileName(response);
+	    if (StringUtils.isBlank(fileName)) {
+	      return null;
+	    }
+	    String[] name_ext = fileName.split("\\.");
+	    File localFile = FileUtils.createTmpFile(inputStream, name_ext[0], name_ext[1], tmpDirFile);
+	    return localFile;
+    } finally {
+    	if (inputStream != null) {
+            inputStream.close();
+        }
     }
-    String[] name_ext = fileName.split("\\.");
-    File localFile = FileUtils.createTmpFile(inputStream, name_ext[0], name_ext[1], tmpDirFile);
-    return localFile;
   }
 
   protected String getFileName(CloseableHttpResponse response) {


### PR DESCRIPTION
在 FileUtils.createTmpFile 调用之前产生任何exception会导致stream无法关闭，从而当前request无法结束，导致所有后继使用httpClient的地方全部卡住。而httpClient是service全局共享的，一旦block所有消息都发不出去了。
